### PR TITLE
fix: update devtool type for webpack5

### DIFF
--- a/compiled/webpack/index.d.ts
+++ b/compiled/webpack/index.d.ts
@@ -628,14 +628,19 @@ declare namespace webpack {
     type Rule = RuleSetRule;
 
     namespace Options {
-        type Devtool = 'eval' | 'inline-source-map' | 'cheap-eval-source-map' | 'cheap-source-map' | 'cheap-module-eval-source-map' | 'cheap-module-source-map' | 'eval-source-map'
+        type DevtoolWebpack4 = 'eval' | 'inline-source-map' | 'cheap-eval-source-map' | 'cheap-source-map' | 'cheap-module-eval-source-map' | 'cheap-module-source-map' | 'eval-source-map'
             | 'source-map' | 'nosources-source-map' | 'hidden-source-map' | 'nosources-source-map' | 'inline-cheap-source-map' | 'inline-cheap-module-source-map' | '@eval'
             | '@inline-source-map' | '@cheap-eval-source-map' | '@cheap-source-map' | '@cheap-module-eval-source-map' | '@cheap-module-source-map' | '@eval-source-map'
             | '@source-map' | '@nosources-source-map' | '@hidden-source-map' | '@nosources-source-map' | '#eval' | '#inline-source-map' | '#cheap-eval-source-map'
             | '#cheap-source-map' | '#cheap-module-eval-source-map' | '#cheap-module-source-map' | '#eval-source-map' | '#source-map' | '#nosources-source-map'
             | '#hidden-source-map' | '#nosources-source-map' | '#@eval' | '#@inline-source-map' | '#@cheap-eval-source-map' | '#@cheap-source-map' | '#@cheap-module-eval-source-map'
             | '#@cheap-module-source-map' | '#@eval-source-map' | '#@source-map' | '#@nosources-source-map' | '#@hidden-source-map' | '#@nosources-source-map' | boolean;
+            
+        type DevtoolWebpack5 = 'eval-cheap-source-map' | 'eval-cheap-module-source-map' | 'eval-nosources-cheap-source-map' | 'eval-nosources-cheap-module-source-map' | 'eval-nosources-source-map'
+            | 'inline-nosources-cheap-source-map' | 'inline-nosources-cheap-module-source-map' | 'inline-nosources-source-map' | 'nosources-cheap-source-map' | 'nosources-cheap-module-source-map'
+            | 'hidden-nosources-cheap-source-map' | 'hidden-nosources-cheap-module-source-map' | 'hidden-nosources-source-map' | 'hidden-cheap-source-map' | 'hidden-cheap-module-source-map';
 
+        type Devtool = DevtoolWebpack4 | DevtoolWebpack5;
         interface Performance {
             /** This property allows webpack to control what files are used to calculate performance hints. */
             assetFilter?(assetFilename: string): boolean;


### PR DESCRIPTION
# 升级原因
本地 umi 项目从 3.2.25 升级到 3.4.2，执行 yarn start 后，报错

![image](https://user-images.githubusercontent.com/31910599/111251769-d25dda00-864a-11eb-8fb5-d63f45c7628f.png)

查看最新 [webpack devtool](https://webpack.js.org/configuration/devtool/) 的文档，发现 devtool 的配置发生了变化，当我在项目中的 config.ts 文件修改后，出现类型报错，

![image](https://user-images.githubusercontent.com/31910599/111252255-ac850500-864b-11eb-83ec-11561dc2e503.png)

后查看 umi 的类型文件中不包含最新的配置，所以进行了补充

## 参考链接
- [webpack/examples/source-map/README.md](https://github.com/webpack/webpack/blob/master/examples/source-map/README.md)
- [webpack-pr-refactor: `devtool` option](https://github.com/webpack/webpack/pull/9689/files)
- [webpack-devtool](https://webpack.js.org/configuration/devtool/)