### PR TITLE
chore: Fix babel bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dts": "node ./scripts/dts",
     "ncc-compiled": "ncc cache clean && taskr ncc",
     "printWebpackInner": "node ./scripts/printWebpackInner",
+    "fixBabelBundle": "node ./scripts/fixBabelBundle",
     "prepublishOnly": "np --yolo --no-publish"
   },
   "taskr": {

--- a/scripts/fixBabelBundle.js
+++ b/scripts/fixBabelBundle.js
@@ -5,17 +5,21 @@ const SCAN_PATH = path.join(__dirname, '../compiled/babel/bundle.js');
 
 try {
   let fileString = fs.readFileSync(SCAN_PATH, 'utf8');
+  const regexp = new RegExp(/(\r|\n)*?.*?__nccwpck_require__\(7905\) = utils;(.|\r|\n)*?__nccwpck_require__\(7905\) = fn;/);
   const targetStr = `
-  // change by scripts/fixBabelBundle.js
-  // __nccwpck_require__(7905) = utils;
-  utils('is-plain-object', 'isObject');
-  utils('shallow-clone', 'clone');
-  utils('kind-of', 'typeOf');
-  __nccwpck_require__(27281);
-  // __nccwpck_require__(7905) = fn;`
-  fileString = fileString.replace(/(\r|\n)*?.*?__nccwpck_require__\(7905\) = utils;(.|\r|\n)*?__nccwpck_require__\(7905\) = fn;/, targetStr);
-  fs.writeFileSync(SCAN_PATH, fileString);
-  console.log('babel build fixed!');
+// change by scripts/fixBabelBundle.js
+utils('is-plain-object', 'isObject');
+utils('shallow-clone', 'clone');
+utils('kind-of', 'typeOf');
+__nccwpck_require__(27281);
+  `;
+  if (regexp.test(fileString) === true) {
+    fileString = fileString.replace(regexp, targetStr);
+    fs.writeFileSync(SCAN_PATH, fileString);
+    console.log('babel build fixed! 手动修复的 babel 代码已完成。');
+  } else {
+    console.error('The code that needs to be repaired manually has changed, please confirm again.需要手动修复的代码已变更，请人工确认。')
+  }
 } catch (err) {
   // eslint-disable-next-line no-console
   console.log(err);

--- a/scripts/fixBabelBundle.js
+++ b/scripts/fixBabelBundle.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const SCAN_PATH = path.join(__dirname, '../compiled/babel/bundle.js');
+
+try {
+  let fileString = fs.readFileSync(SCAN_PATH, 'utf8');
+  const targetStr = `
+  // change by scripts/fixBabelBundle.js
+  // __nccwpck_require__(7905) = utils;
+  utils('is-plain-object', 'isObject');
+  utils('shallow-clone', 'clone');
+  utils('kind-of', 'typeOf');
+  __nccwpck_require__(27281);
+  // __nccwpck_require__(7905) = fn;`
+  fileString = fileString.replace(/(\r|\n)*?.*?__nccwpck_require__\(7905\) = utils;(.|\r|\n)*?__nccwpck_require__\(7905\) = fn;/, targetStr);
+  fs.writeFileSync(SCAN_PATH, fileString);
+  console.log('babel build fixed!');
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.log(err);
+}

--- a/taskfile.js
+++ b/taskfile.js
@@ -56,7 +56,7 @@ export async function ncc_babel_bundle(task, opts) {
       externals: bundleExternals,
       minify: false,
     })
-    .target('compiled/babel')
+    .target('compiled/babel');
 }
 
 const babelBundlePackages = {


### PR DESCRIPTION
加了一个脚本，代替手动修复。

> 另外，还有 babel 也有一处 Lazily required module dependencies 需要手动处理，先注释 __nccwpck_require__(7905) = utils; 和 __nccwpck_require__(7905) = fn;，然后修改中间的 __nccwpck_require__(7905) 为 utils。